### PR TITLE
Add ZSH preset

### DIFF
--- a/src/zsh.py
+++ b/src/zsh.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from dotcommon.util import lines_starting_with
+from dotcommon.crawl import crawl
+
+
+def aliases(text):
+    "Aliases"
+    return lines_starting_with("alias ", text)
+
+def theme(text):
+    "Theme"
+    return lines_starting_with("ZSH_THEME=", text)
+
+def exports(text):
+    "Exports"
+    return lines_starting_with("export ", text)
+
+def keybindings(text):
+    "Keybindings"
+    return lines_starting_with("bindkey ", text)
+
+crawl("ZSH", "zshrc", aliases, exports, theme, keybindings)


### PR DESCRIPTION
fix #4 
Containing:
 - aliases
 - theme
 - exports
 - keybindings

An other interesting thing are the plugins. But they are usually all in one line like `plugins=(git git-prompt git-extras)` which leads to wrong output.

The zsh.py file produces the following output:

```markdown
Aliases
~~~~~~~


==================================  ==
``alias vim="nvim"``                42
``alias vim='nvim'``                31
``alias grep='grep --color=auto'``  30
``alias gs="git status"``           26
``alias gs='git status'``           25
``alias g='git'``                   25
``alias rm='rm -i'``                23
``alias vi="nvim"``                 22
``alias ..='cd ..'``                22
``alias ga='git add'``              21
==================================  ==


Exports
~~~~~~~


=================================  ===
``export LANG=en_US.UTF-8``        106
``export ZSH=$HOME/.oh-my-zsh``     90
``export NVM_DIR="$HOME/.nvm"``     83
``export LC_ALL=en_US.UTF-8``       67
``export ZSH="$HOME/.oh-my-zsh"``   63
``export KEYTIMEOUT=1``             60
``export EDITOR=vim``               49
``export GPG_TTY=$(tty)``           40
``export GOPATH=$HOME/go``          36
``export TERM=xterm-256color``      33
=================================  ===


Theme
~~~~~


===========================================  ==
``ZSH_THEME="robbyrussell"``                 79
``ZSH_THEME="powerlevel10k/powerlevel10k"``  55
``ZSH_THEME="agnoster"``                     45
``ZSH_THEME="powerlevel9k/powerlevel9k"``    26
``ZSH_THEME="spaceship"``                    23
``ZSH_THEME="ys"``                           14
``ZSH_THEME=""``                             11
``ZSH_THEME="bira"``                         11
``ZSH_THEME="random"``                        8
``ZSH_THEME=powerlevel10k/powerlevel10k``     7
===========================================  ==


Keybindings
~~~~~~~~~~~


=====================================================  ===
``bindkey -v``                                         136
``bindkey -e``                                          65
``bindkey -M menuselect 'l' vi-forward-char``           34
``bindkey -M menuselect 'j' vi-down-line-or-history``   34
``bindkey -M menuselect 'h' vi-backward-char``          33
``bindkey -M menuselect 'k' vi-up-line-or-history``     33
``bindkey -v '^?' backward-delete-char``                23
``bindkey '^[[A' history-substring-search-up``          21
``bindkey '^[[B' history-substring-search-down``        21
``bindkey '^e' edit-command-line``                      19
=====================================================  ===
```